### PR TITLE
Comma-separate the `global` inline JSHint configs

### DIFF
--- a/test/test-file-creation.js
+++ b/test/test-file-creation.js
@@ -1,4 +1,4 @@
-/*global describe beforeEach it */
+/*global describe, beforeEach, it */
 'use strict';
 var path = require('path');
 var helpers = require('yeoman-generator').test;


### PR DESCRIPTION
According to http://www.jshint.com/docs, the variable names
after an inline `global` statement must be comma-seperated:

> These comments start either with `jshint` or `global`
>    and are followed by a comma-separated list of values
